### PR TITLE
bit of feature parity between our 7.4 and 8.1 images. Adds better no …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN docker-php-ext-enable zip \
 RUN sed -ri -e 's!expose_php = On!expose_php = Off!g' $PHP_INI_DIR/php.ini-production \
     && sed -ri -e 's!ServerTokens OS!ServerTokens Prod!g' /etc/apache2/conf-available/security.conf \
     && sed -ri -e 's!ServerSignature On!ServerSignature Off!g' /etc/apache2/conf-available/security.conf \
+    && sed -ri -e 's!KeepAliveTimeout .*!KeepAliveTimeout 65!g' /etc/apache2/apache2.conf \
     && mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
 COPY php/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini.disabled

--- a/apache/disable-elb-healthcheck-log.conf
+++ b/apache/disable-elb-healthcheck-log.conf
@@ -1,4 +1,4 @@
 <IfModule mod_setenvif.c>
-  SetEnvIf User-Agent "^ELB-HealthChecker$" dontlog
+  SetEnvIf User-Agent "^ELB-HealthChecker" dontlog
   CustomLog ${APACHE_LOG_DIR}/access.log combined env=!dontlog
 </IfModule>


### PR DESCRIPTION
…logging of health check requests, ups keep alive timeout to be greater than the idle timeout of the ALB